### PR TITLE
Remove obsolete CRD copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.1.0]
+### Changed
+Removed obsolete copying of CRDs
+
 ## [v1.0.0]
 ### Added
 

--- a/class/crossplane.yml
+++ b/class/crossplane.yml
@@ -23,9 +23,3 @@ parameters:
           release_name: ${_instance}
           namespace: ${crossplane:namespace}
         output_path: crossplane/01_helmchart
-      # Until Kapitan supports Helm 3 charts, CRDs need to be copied explicitly
-      # https://github.com/deepmind/kapitan/pull/648
-      - input_type: copy
-        input_paths:
-          - crossplane/helmcharts/crossplane-${crossplane:charts:crossplane}/crds/
-        output_path: crossplane/00_crds/


### PR DESCRIPTION
The latest kapitan version supports helm3 charts already
and starting with crossplane 1.2 the CRDs are managed via
`initContainers` and not helm anymore.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
