### PR TITLE
OpenShift4 ServiceAccount does not work properly with ArgoCD and Crossplane Helm Chart

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -2,15 +2,30 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.crossplane;
 local argocd = import 'lib/argocd.libjsonnet';
+local on_openshift4 = inv.parameters.facts.distribution == 'openshift4';
+
+local ignore_diff_sa = {
+  group: '',
+  kind: 'ServiceAccount',
+  name: '',
+  jsonPointers: [ '/imagePullSecrets' ],
+};
+
+local ignore_diff_cr = {
+  group: 'rbac.authorization.k8s.io',
+  kind: 'ClusterRole',
+  name: 'crossplane',
+  jsonPointers: [ '/rules' ],
+};
 
 local app = argocd.App('crossplane', params.namespace) {
   spec+: {
-    ignoreDifferences: [ {
-      group: 'rbac.authorization.k8s.io',
-      kind: 'ClusterRole',
-      name: name,
-      jsonPointers: [ '/rules' ],
-    } for name in [ 'crossplane' ] ],
+    ignoreDifferences:
+      [ ignore_diff_cr ] +
+      if on_openshift4 then
+        [ ignore_diff_sa ]
+      else
+        [],
   },
 };
 

--- a/tests/golden/openshift4-with-provider/crossplane/apps/crossplane.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/apps/crossplane.yaml
@@ -5,3 +5,8 @@ spec:
         - /rules
       kind: ClusterRole
       name: crossplane
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount
+      name: ''

--- a/tests/golden/openshift4/crossplane/apps/crossplane.yaml
+++ b/tests/golden/openshift4/crossplane/apps/crossplane.yaml
@@ -5,3 +5,8 @@ spec:
         - /rules
       kind: ClusterRole
       name: crossplane
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount
+      name: ''


### PR DESCRIPTION
Problem:
 - ArgoCD recycles the ServiceAccount from git repository meanwhile OpenShift adds another ImagePullSecret to the ServiceAccount. ArgoCD sees the differences and tries to update it thus making an infinite loop of updates from OpenShit and Argo.

Solutions:
 - **Use `ingoreDifferences` feature from ArgoCD so that it ignores the `imagePullSecret` path (implemented here)**
 - Remove the default `dockerhub` through `helmValues` with `imagePullSecrets: []`
 - Update the post processor script and remove `imagePullSecrets`.

I decided to preserve the original HelmChart and leave `dockerhub` inside `imagePullSecrets`

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
