### PR TITLE
Enable webhooks by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,3 +43,5 @@ parameters:
           cpu: 500m
       metrics:
         enabled: ${crossplane:monitoring:enabled}
+      webhooks:
+        enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -169,7 +169,7 @@ parameters:
   crossplane:
     images:
       crossplane:
-        image: mymirror.io/crossplane/crossplane
+        registry: mymirror.io
     providers:
       helm:
         package: crossplane/provider-helm:v0.3.5

--- a/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
@@ -48,12 +48,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: LEADER_ELECTION
               value: 'true'
+            - name: WEBHOOK_TLS_SECRET_NAME
+              value: webhook-tls-secret
+            - name: WEBHOOK_TLS_CERT_DIR
+              value: /webhook/tls
           image: docker.io/crossplane/crossplane:v1.9.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
             - containerPort: 8080
               name: metrics
+            - containerPort: 9443
+              name: webhooks
           resources:
             limits:
               cpu: 1000m
@@ -69,6 +75,8 @@ spec:
           volumeMounts:
             - mountPath: /cache
               name: package-cache
+            - mountPath: /webhook/tls
+              name: webhook-tls-secret
       initContainers:
         - args:
             - core
@@ -78,6 +86,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: WEBHOOK_TLS_SECRET_NAME
+              value: webhook-tls-secret
+            - name: WEBHOOK_SERVICE_NAME
+              value: crossplane-webhooks
+            - name: WEBHOOK_SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEBHOOK_SERVICE_PORT
+              value: '9443'
           image: docker.io/crossplane/crossplane:v1.9.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
@@ -100,3 +118,6 @@ spec:
             medium: null
             sizeLimit: 5Mi
           name: package-cache
+        - name: webhook-tls-secret
+          secret:
+            secretName: webhook-tls-secret

--- a/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
+++ b/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-tls-secret
+type: Opaque

--- a/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane-webhooks
+spec:
+  ports:
+    - port: 9443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: crossplane
+    release: crossplane

--- a/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
@@ -48,12 +48,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: LEADER_ELECTION
               value: 'true'
+            - name: WEBHOOK_TLS_SECRET_NAME
+              value: webhook-tls-secret
+            - name: WEBHOOK_TLS_CERT_DIR
+              value: /webhook/tls
           image: docker.io/crossplane/crossplane:v1.9.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
             - containerPort: 8080
               name: metrics
+            - containerPort: 9443
+              name: webhooks
           resources:
             limits:
               cpu: 1000m
@@ -69,6 +75,8 @@ spec:
           volumeMounts:
             - mountPath: /cache
               name: package-cache
+            - mountPath: /webhook/tls
+              name: webhook-tls-secret
       initContainers:
         - args:
             - core
@@ -78,6 +86,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: WEBHOOK_TLS_SECRET_NAME
+              value: webhook-tls-secret
+            - name: WEBHOOK_SERVICE_NAME
+              value: crossplane-webhooks
+            - name: WEBHOOK_SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEBHOOK_SERVICE_PORT
+              value: '9443'
           image: docker.io/crossplane/crossplane:v1.9.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
@@ -100,3 +118,6 @@ spec:
             medium: null
             sizeLimit: 5Mi
           name: package-cache
+        - name: webhook-tls-secret
+          secret:
+            secretName: webhook-tls-secret

--- a/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
+++ b/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-tls-secret
+type: Opaque

--- a/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane-webhooks
+spec:
+  ports:
+    - port: 9443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: crossplane
+    release: crossplane

--- a/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
@@ -48,12 +48,18 @@ spec:
               fieldPath: metadata.namespace
         - name: LEADER_ELECTION
           value: 'true'
+        - name: WEBHOOK_TLS_SECRET_NAME
+          value: webhook-tls-secret
+        - name: WEBHOOK_TLS_CERT_DIR
+          value: /webhook/tls
         image: docker.io/crossplane/crossplane:v1.9.0
         imagePullPolicy: IfNotPresent
         name: crossplane
         ports:
         - containerPort: 8080
           name: metrics
+        - containerPort: 9443
+          name: webhooks
         resources:
           limits:
             cpu: 1000m
@@ -69,6 +75,8 @@ spec:
         volumeMounts:
         - mountPath: /cache
           name: package-cache
+        - mountPath: /webhook/tls
+          name: webhook-tls-secret
       initContainers:
       - args:
         - core
@@ -78,6 +86,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_TLS_SECRET_NAME
+          value: webhook-tls-secret
+        - name: WEBHOOK_SERVICE_NAME
+          value: crossplane-webhooks
+        - name: WEBHOOK_SERVICE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: WEBHOOK_SERVICE_PORT
+          value: '9443'
         image: docker.io/crossplane/crossplane:v1.9.0
         imagePullPolicy: IfNotPresent
         name: crossplane-init
@@ -100,3 +118,6 @@ spec:
           medium: null
           sizeLimit: 5Mi
         name: package-cache
+      - name: webhook-tls-secret
+        secret:
+          secretName: webhook-tls-secret

--- a/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-tls-secret
+type: Opaque

--- a/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane-webhooks
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: crossplane
+    release: crossplane

--- a/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
@@ -48,12 +48,18 @@ spec:
               fieldPath: metadata.namespace
         - name: LEADER_ELECTION
           value: 'true'
+        - name: WEBHOOK_TLS_SECRET_NAME
+          value: webhook-tls-secret
+        - name: WEBHOOK_TLS_CERT_DIR
+          value: /webhook/tls
         image: docker.io/crossplane/crossplane:v1.9.0
         imagePullPolicy: IfNotPresent
         name: crossplane
         ports:
         - containerPort: 8080
           name: metrics
+        - containerPort: 9443
+          name: webhooks
         resources:
           limits:
             cpu: 1000m
@@ -69,6 +75,8 @@ spec:
         volumeMounts:
         - mountPath: /cache
           name: package-cache
+        - mountPath: /webhook/tls
+          name: webhook-tls-secret
       initContainers:
       - args:
         - core
@@ -78,6 +86,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_TLS_SECRET_NAME
+          value: webhook-tls-secret
+        - name: WEBHOOK_SERVICE_NAME
+          value: crossplane-webhooks
+        - name: WEBHOOK_SERVICE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: WEBHOOK_SERVICE_PORT
+          value: '9443'
         image: docker.io/crossplane/crossplane:v1.9.0
         imagePullPolicy: IfNotPresent
         name: crossplane-init
@@ -100,3 +118,6 @@ spec:
           medium: null
           sizeLimit: 5Mi
         name: package-cache
+      - name: webhook-tls-secret
+        secret:
+          secretName: webhook-tls-secret

--- a/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
+++ b/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-tls-secret
+type: Opaque

--- a/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/openshift4/crossplane/crossplane/01_helmchart/crossplane/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane-webhooks
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: crossplane
+    release: crossplane


### PR DESCRIPTION
Starting with Crossplane v1.7 it's possible to deploy the webhooks feature.
This allows providers to define admission webhooks (validate & mutate). The config and the TLS certificate is managed completely by Crossplane, so it should be safe to enable by default.
There should be no impact with providers that don't have or need admission webhooks.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
