### PR TITLE
Add apiextensions apiGroup to CR for RBAC-Manager

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -79,6 +79,7 @@ local rbacFinalizerRole = kube.ClusterRole('crossplane-rbac-manager:finalizer') 
     {
       apiGroups: [
         'pkg.crossplane.io',
+        'apiextensions.crossplane.io',
       ],
       resources: [
         '*/finalizers',

--- a/tests/golden/defaults-with-provider/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
+++ b/tests/golden/defaults-with-provider/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - pkg.crossplane.io
+      - apiextensions.crossplane.io
     resources:
       - '*/finalizers'
     verbs:

--- a/tests/golden/defaults/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
+++ b/tests/golden/defaults/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - pkg.crossplane.io
+      - apiextensions.crossplane.io
     resources:
       - '*/finalizers'
     verbs:

--- a/tests/golden/openshift4-with-provider/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - pkg.crossplane.io
+      - apiextensions.crossplane.io
     resources:
       - '*/finalizers'
     verbs:

--- a/tests/golden/openshift4/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
+++ b/tests/golden/openshift4/crossplane/crossplane/01_rbac_finalizer_clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - pkg.crossplane.io
+      - apiextensions.crossplane.io
     resources:
       - '*/finalizers'
     verbs:


### PR DESCRIPTION
The RBAC-Manager requires permissions to set finalizers on the XRD, as it sets ownerReferences to the created clusterRoles for each XRD.

As openshift doesn't allow this by default we need to add the respective `clusterRole`

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
