### PR TITLE
Add option to define namespace labels and annotations

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,9 @@
 parameters:
   crossplane:
     namespace: syn-crossplane
+    namespaceLabels: {}
+    namespaceAnnotations: {}
+
     charts:
       crossplane: 1.11.0
     images:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -112,7 +112,12 @@ local namespace =
 ;
 
 {
-  '00_namespace': namespace,
+  '00_namespace': namespace {
+    metadata+: {
+      labels+: params.namespaceLabels,
+      annotations+: params.namespaceAnnotations,
+    },
+  },
   '01_rbac_finalizer_clusterrole': rbacFinalizerRole,
   '01_rbac_finalizer_clusterrolebinding': rbacFinalizerRoleBinding,
   [if std.length(providers) > 0 then '10_providers']: providers,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,22 @@ default:: `syn-crossplane`
 
 The namespace in which to deploy Crossplane.
 
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional annotations to add to the created namespace.
+
 == `providers`
 
 [horizontal]

--- a/tests/golden/openshift4/crossplane/crossplane/00_namespace.yaml
+++ b/tests/golden/openshift4/crossplane/crossplane/00_namespace.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
   labels:
+    foo: bar
     name: syn-crossplane
   name: syn-crossplane

--- a/tests/openshift4.yml
+++ b/tests/openshift4.yml
@@ -1,4 +1,8 @@
 parameters:
   facts:
     distribution: openshift4
-  crossplane: {}
+  crossplane:
+    namespaceLabels:
+      foo: bar
+    namespaceAnnotations:
+      openshift.io/node-selector: node-role.kubernetes.io/infra=


### PR DESCRIPTION
This gives us some flexibilty and can be helpful in multiple situations. The main usecase currently is that we can schedule crossplane on infra nodes on OpenShift using the annotation `openshift.io/node-selector`




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
