### PR TITLE
Additional configuration to support OKE

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -2,7 +2,7 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.crossplane;
 local argocd = import 'lib/argocd.libjsonnet';
-local on_openshift4 = inv.parameters.facts.distribution == 'openshift4';
+local on_openshift4 = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
 
 local ignore_diff_sa = {
   group: '',

--- a/postprocess/patch_operator_deployment.jsonnet
+++ b/postprocess/patch_operator_deployment.jsonnet
@@ -1,7 +1,7 @@
 local com = import 'lib/commodore.libjsonnet';
 local inv = com.inventory();
 
-local on_openshift4 = inv.parameters.facts.distribution;
+local on_openshift4 = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
 local run_as_user = {
   runAsUser: null,
 };
@@ -31,7 +31,7 @@ local fixup(obj) =
   else
     obj;
 
-if on_openshift4 == 'openshift4' then
+if on_openshift4 then
   com.fixupDir(std.extVar('output_path'), fixup)
 else
   {}


### PR DESCRIPTION
Follow-up for #72, there are more changes required to treat oke like openshift4

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
