### PR TITLE
Add app finalizers config

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,6 +4,10 @@ parameters:
     namespaceLabels: {}
     namespaceAnnotations: {}
 
+    argocd:
+      application:
+        finalizers:
+          - resources-finalizer.argocd.argoproj.io
     charts:
       crossplane: 1.12.3
     images:

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -19,6 +19,9 @@ local ignore_diff_cr = {
 };
 
 local app = argocd.App('crossplane', params.namespace) {
+  metadata+: {
+    finalizers: params.argocd.application.finalizers,
+  },
   spec+: {
     ignoreDifferences:
       [ ignore_diff_cr ] +

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -206,3 +206,12 @@ parameters:
         requests:
           cpu: 1000m
 ----
+
+
+== `argocd.application.finalizers`
+
+[horizontal]
+type:: array
+default:: `[- resources-finalizer.argocd.argoproj.io]`
+
+This parameter allows to configure ArgoCD App finalizers.

--- a/tests/golden/defaults-with-provider/crossplane/apps/crossplane.yaml
+++ b/tests/golden/defaults-with-provider/crossplane/apps/crossplane.yaml
@@ -1,3 +1,6 @@
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
     - group: rbac.authorization.k8s.io

--- a/tests/golden/defaults/crossplane/apps/crossplane.yaml
+++ b/tests/golden/defaults/crossplane/apps/crossplane.yaml
@@ -1,3 +1,6 @@
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
     - group: rbac.authorization.k8s.io

--- a/tests/golden/openshift4-with-provider/crossplane/apps/crossplane.yaml
+++ b/tests/golden/openshift4-with-provider/crossplane/apps/crossplane.yaml
@@ -1,3 +1,6 @@
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
     - group: rbac.authorization.k8s.io

--- a/tests/golden/openshift4/crossplane/apps/crossplane.yaml
+++ b/tests/golden/openshift4/crossplane/apps/crossplane.yaml
@@ -1,3 +1,6 @@
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   ignoreDifferences:
     - group: rbac.authorization.k8s.io


### PR DESCRIPTION
This feature request allows to configure ArgoCD Application CRD finalizers.

This PR is necessary to allow a smooth migration of this component into appcat component. It will make sure once Crossplane has been moved into appcat the migration (ArgoCD) will not remove Crossplane itself.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
